### PR TITLE
chore: drop synchronize trigger, add ready_for_review + @claude review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,7 +2,9 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, ready_for_review]
+  issue_comment:
+    types: [created]
 
 permissions:
   id-token: write
@@ -12,6 +14,11 @@ permissions:
 
 jobs:
   review:
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       startsWith(github.event.comment.body, '@claude review'))
     uses: Gemma-Analytics/.github/.github/workflows/claude-review.yml@main
     with:
       additional_instructions: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,8 +17,12 @@ permissions:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issue_comment' &&
+       contains(github.event.comment.body, '@claude') &&
+       !startsWith(github.event.comment.body, '@claude review')) ||
+      (github.event_name == 'pull_request_review_comment' &&
+       contains(github.event.comment.body, '@claude') &&
+       !startsWith(github.event.comment.body, '@claude review')) ||
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
     uses: Gemma-Analytics/.github/.github/workflows/claude.yml@main
     secrets: inherit


### PR DESCRIPTION
## Summary

Aligns with [Gemma-Analytics/.github PR #20](https://github.com/Gemma-Analytics/.github/pull/20).

- Drop `synchronize` trigger — Claude no longer re-reviews on every commit push
- Add `ready_for_review` trigger — draft→ready transitions get reviewed
- Add `issue_comment` trigger + job-level `if:` gate for `@claude review` comment
- Add `!startsWith(body, '@claude review')` negation in `claude.yml` (where applicable) so `@claude review` routes to the review workflow, not the generic responder

## Merge order

Merge [Gemma-Analytics/.github#20](https://github.com/Gemma-Analytics/.github/pull/20) first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)