### PR TITLE
chore: test claude review workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,4 @@ The process requires the following GitHub secrets to be configured:
 - `SNOWFLAKE_*`: Snowflake credentials for running tests
 
 For full details on the release workflow, see [RELEASE_WORKFLOW.md](docs/RELEASE_WORKFLOW.md).
+


### PR DESCRIPTION
Dummy PR to verify the Claude Code Review workflow fires correctly on `pull_request: [opened]`.

Close once confirmed working.