### PR TITLE
fix: restrict auto-UNSET to user RSA public keys only

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -125,6 +125,30 @@ def test_resolve_objects_no_unset_for_warehouse_params():
     assert result["alter"] == []
 
 
+def test_resolve_objects_no_unset_for_database_params():
+    """Database params (comment) never auto-unset."""
+    from tundri.objects import Database
+
+    existing = Database(name="MY_DB", params={"comment": "set out of band"})
+    ought = Database(name="MY_DB", params={})
+
+    result = resolve_objects(frozenset([existing]), frozenset([ought]))
+
+    assert result["alter"] == []
+
+
+def test_resolve_objects_no_unset_for_role_params():
+    """Role params (comment) never auto-unset."""
+    from tundri.objects import Role
+
+    existing = Role(name="MY_ROLE", params={"comment": "set out of band"})
+    ought = Role(name="MY_ROLE", params={})
+
+    result = resolve_objects(frozenset([existing]), frozenset([ought]))
+
+    assert result["alter"] == []
+
+
 def test_build_statements_list():
     # Prepare test input
     test_statements = {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,31 +2,6 @@ from tundri.core import build_statements_list, build_summary_line, resolve_objec
 from tundri.objects import User, Warehouse
 
 
-def test_resolve_objects_generates_unset_for_removed_param():
-    """Removing a param from spec should generate an UNSET statement."""
-    existing = Warehouse(
-        name="WH1",
-        params={
-            "warehouse_size": "xsmall",
-            "auto_suspend": "60",
-            "comment": "my warehouse",
-        },
-    )
-    ought = Warehouse(
-        name="WH1",
-        params={"warehouse_size": "xsmall", "auto_suspend": "60"},  # comment removed
-    )
-
-    result = resolve_objects(frozenset([existing]), frozenset([ought]))
-
-    assert result["create"] == []
-    assert result["drop"] == []
-    assert len(result["alter"]) == 1
-    unset_stmt = result["alter"][0]
-    assert "UNSET" in unset_stmt
-    assert "comment" in unset_stmt.lower()
-
-
 def test_resolve_objects_no_unset_when_param_not_set_in_snowflake():
     """No UNSET should be generated when the param has no value in Snowflake."""
     existing = Warehouse(
@@ -61,20 +36,16 @@ def test_resolve_objects_no_unset_when_param_is_null_string_in_snowflake():
 
 def test_resolve_objects_generates_set_and_unset_simultaneously():
     """Both SET and UNSET can be generated in the same run for the same object."""
-    existing = Warehouse(
-        name="WH1",
+    existing = User(
+        name="testuser",
         params={
-            "warehouse_size": "xsmall",
-            "auto_suspend": "60",
-            "comment": "old comment",
+            "default_role": "old_role",
+            "rsa_public_key": "MIIBIjANBgkq...",
         },
     )
-    ought = Warehouse(
-        name="WH1",
-        params={
-            "warehouse_size": "medium",
-            "auto_suspend": "60",
-        },  # size changed, comment removed
+    ought = User(
+        name="testuser",
+        params={"default_role": "new_role"},  # role changed → SET; rsa key gone → UNSET
     )
 
     result = resolve_objects(frozenset([existing]), frozenset([ought]))
@@ -129,6 +100,29 @@ def test_resolve_objects_generates_unset_for_rsa_keys():
     unset_stmts = [s for s in result["alter"] if "UNSET" in s]
     assert len(unset_stmts) == 1
     assert "rsa_public_key" in unset_stmts[0].lower()
+
+
+def test_resolve_objects_no_unset_for_warehouse_params():
+    """Warehouse params (comment, resource_monitor, cluster counts) never auto-unset."""
+    existing = Warehouse(
+        name="WH1",
+        params={
+            "warehouse_size": "xsmall",
+            "auto_suspend": "60",
+            "comment": "set out of band",
+            "resource_monitor": "MY_MONITOR",
+            "max_cluster_count": "5",
+            "min_cluster_count": "1",
+        },
+    )
+    ought = Warehouse(
+        name="WH1",
+        params={"warehouse_size": "xsmall", "auto_suspend": "60"},
+    )
+
+    result = resolve_objects(frozenset([existing]), frozenset([ought]))
+
+    assert result["alter"] == []
 
 
 def test_build_statements_list():

--- a/tundri/core.py
+++ b/tundri/core.py
@@ -33,23 +33,17 @@ params_to_ignore_in_alter = {
     "warehouse": ["initially_suspended", "statement_timeout_in_seconds"],
 }
 
-# Params that should be UNSET in Snowflake when removed from the spec.
-# When a param exists in Snowflake with a non-empty value but is absent from the spec,
-# an UNSET statement is generated to reset it to its default. Extend this list with any
-# user-configurable param that should be cleared when removed from the spec.
+# Only credential params are auto-UNSET when absent from the spec (removing a public key
+# from spec should revoke it in Snowflake). All other params are treated as out-of-band:
+# they are only modified when explicitly listed in the spec's meta block.
 params_to_unset_if_absent = {
     "user": [
         "rsa_public_key",
         "rsa_public_key_2",
     ],
-    "warehouse": [
-        "comment",
-        "resource_monitor",
-        "max_cluster_count",
-        "min_cluster_count",
-    ],
-    "database": ["comment"],
-    "role": ["comment"],
+    "warehouse": [],
+    "database": [],
+    "role": [],
     "schema": [],
 }
 

--- a/uv.lock
+++ b/uv.lock
@@ -1760,7 +1760,7 @@ wheels = [
 
 [[package]]
 name = "tundri"
-version = "1.3.5"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "gemma-permifrost" },


### PR DESCRIPTION
## Summary

- Removes `comment`, `resource_monitor`, `max_cluster_count`, and `min_cluster_count` from the warehouse auto-UNSET list
- Removes `comment` from the database and role auto-UNSET lists
- Only credential params (`rsa_public_key`, `rsa_public_key_2`) are now auto-cleared when absent from spec — removing a public key from spec is an intentional revocation; everything else is out-of-band
- `SET` behaviour is unchanged: any param explicitly listed in a `meta:` block is still enforced

**Root cause.** `params_to_unset_if_absent` in `core.py` opted in warehouse/database/role params, causing tundri to emit `ALTER ... UNSET comment` (and others) on every reconcile whenever the value existed in Snowflake but wasn't in the YAML. Values set out-of-band (e.g. warehouse comments from the Snowflake UI) were silently blown away each run.

## Test plan

- [x] Deleted `test_resolve_objects_generates_unset_for_removed_param` — was asserting warehouse `comment` UNSET; now wrong and redundant with the RSA-key test
- [x] Updated `test_resolve_objects_generates_set_and_unset_simultaneously` to use a `User` (role change + RSA key removal) to keep SET+UNSET-simultaneously coverage
- [x] Added `test_resolve_objects_no_unset_for_warehouse_params` — pinning test that would have caught the original bug
- [x] All 12 unit tests pass, lint clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)